### PR TITLE
Fix leaks

### DIFF
--- a/lib/Net/XMPP/PrivacyLists.pm
+++ b/lib/Net/XMPP/PrivacyLists.pm
@@ -89,6 +89,7 @@ sub new
 sub init
 {
     my $self = shift;
+    weaken $self;
 
     $self->{CONNECTION}-> SetXPathCallBacks('/iq[@type="result" or @type="set"]/query[@xmlns="jabber:iq:privacy"]'=>sub{ $self->handler(@_) });
 }

--- a/lib/Net/XMPP/Protocol.pm
+++ b/lib/Net/XMPP/Protocol.pm
@@ -1851,6 +1851,7 @@ sub MessageSend
 sub PresenceDB
 {
     my $self = shift;
+    weaken $self;
 
     $self->SetXPathCallBacks('/presence'=>sub{ shift; $self->PresenceDBParse(@_) });
 }
@@ -2710,6 +2711,7 @@ sub Roster
 sub RosterDB
 {
     my $self = shift;
+    weaken $self;
 
     $self->SetXPathCallBacks('/iq[@type="result" or @type="set"]/query[@xmlns="jabber:iq:roster"]'=>sub{ shift; $self->RosterDBParse(@_) });
 }
@@ -2993,6 +2995,7 @@ sub RosterDBRemove
 sub TLSInit
 {
     my $self = shift;
+    weaken $self;
 
     $TLS_CALLBACK = sub{ $self->ProcessTLSStanza( @_ ) };
     $self->SetDirectXPathCallBacks('/[@xmlns="'.&ConstXMLNS("xmpp-tls").'"]'=>$TLS_CALLBACK);
@@ -3181,6 +3184,7 @@ sub TLSSendStartTLS
 sub SASLInit
 {
     my $self = shift;
+    weaken $self;
 
     $SASL_CALLBACK = sub{ $self->ProcessSASLStanza( @_ ) };
     $self->SetDirectXPathCallBacks('/[@xmlns="'.&ConstXMLNS("xmpp-sasl").'"]'=> $SASL_CALLBACK);

--- a/t/gtalk.t
+++ b/t/gtalk.t
@@ -52,7 +52,7 @@ BEGIN {
 }
 
 my $repeat = 5;
-plan tests => 2 + 6 * $repeat;
+plan tests => 9 + 6 * $repeat;
 
 # TODO ask user if it is ok to do network tests!
 print_size('before loading Net::XMPP');
@@ -90,17 +90,14 @@ for (2..$repeat) {
 }
 
 # The leakage shown here happens even before Authentication is called
-#SKIP: {
-#    skip 'Devel::LeakGuard::Object is needed', 1 if not $leak_guard;
-#    my $warn;
-#    local $SIG{__WARN__} = sub { $warn = shift };
-#    leakguard {
-#         run();
-#    };
-#
-#    ok(!$warn, 'leaking') or diag $warn;
-#}
+skip 'Devel::LeakGuard::Object is needed', 1 if not $leak_guard;
+my $warn;
+local $SIG{__WARN__} = sub { $warn = shift };
+leakguard {
+        run();
+};
 
+ok(!$warn, 'leaking') or diag $warn;
 
 # as I can see setting up the connection leaks in the first 5 attempts 
 # and then it stops leaking. I tried it with repeate=25

--- a/t/gtalk.t
+++ b/t/gtalk.t
@@ -90,12 +90,14 @@ for (2..$repeat) {
 }
 
 # The leakage shown here happens even before Authentication is called
-skip 'Devel::LeakGuard::Object is needed', 1 if not $leak_guard;
 my $warn;
-local $SIG{__WARN__} = sub { $warn = shift };
-leakguard {
-        run();
-};
+SKIP: {
+    skip 'Devel::LeakGuard::Object is needed', 6 if not $leak_guard;
+    local $SIG{__WARN__} = sub { $warn = shift };
+    leakguard {
+            run();
+    };
+}
 
 ok(!$warn, 'leaking') or diag $warn;
 

--- a/t/memory_leak.t
+++ b/t/memory_leak.t
@@ -22,8 +22,6 @@ check_leak(
     'nothing',
 );
 
-TODO: {
-   local $TODO = 'fix leak';
 check_leak(
     sub {
         my $conn   = Net::XMPP::Client->new;
@@ -46,7 +44,6 @@ check_leak(
     },
     'connect',
 );
-}
 
 
 sub check_leak{


### PR DESCRIPTION
This fixes a few memory leaks (weakens the ref to $self) and restores a TODO memory leak test as well as uncommenting one for gtallk.t (note that Google doesn't support XMPP anymore, so this might be something that should go).
