### PR TITLE
Support for virtualhosts

### DIFF
--- a/lib/Net/XMPP/Connection.pm
+++ b/lib/Net/XMPP/Connection.pm
@@ -105,6 +105,12 @@ sub init
     $self->{SERVER}->{tls} = $self->_arg("tls",0);
     $self->{SERVER}->{ssl} = $self->_arg("ssl",0);
     $self->{SERVER}->{connectiontype} = $self->_arg("connectiontype","tcpip");
+    if (exists $self->{ARGS}->{servername}) {
+        $self->{SERVER}->{servername} = $self->{ARGS}->{servername};
+    }
+    if (exists $self->{ARGS}->{srv}) {
+        $self->{SERVER}->{srv} = $self->{ARGS}->{srv};
+    }
 
     $self->{CONNECTED} = 0;
     $self->{DISCONNECTED} = 0;
@@ -175,6 +181,14 @@ sub Connect
                     ),
                     ( defined $self->{SERVER}->{srv}
                         ? (srv => '_xmpp-client._tcp')
+                        : ()
+                    ),
+                    (exists($self->{SERVER}->{servername})
+                        ? (servername => $self->{SERVER}->{servername} )
+                        : ()
+                    ),
+                    (exists($self->{SERVER}->{srv})
+                        ? (srv => $self->{SERVER}->{srv} )
                         : ()
                     ),
                    );


### PR DESCRIPTION
Note that this requires PR to XML::Stream -
  [https://github.com/dap/XML-Stream/pull/18](https://github.com/dap/XML-Stream/pull/18)

From [http://toroid.org/misc/net-xmpp-virtualhost.diff](http://toroid.org/misc/net-xmpp-virtualhost.diff)
Described at [http://toroid.org/net-xmpp-virtualhost-support](http://toroid.org/net-xmpp-virtualhost-support)

This is necessary to allow changes to be made to Net::XMPP (and similar)
to support cases where the user is trying to connect to a host that has
an SRV record, but must authenticate and the like as the starting
hostname, not the hostname pointed at by the SRV.

I apologize if you've rejected this in the past for some reason.
