### PR TITLE
Fix tests failing under Perl 5.26 w/ PERL_USE_UNSAFE_INC=0

### DIFF
--- a/t/iq.t
+++ b/t/iq.t
@@ -3,7 +3,7 @@ use Test::More tests=>115;
 
 BEGIN{ use_ok( "Net::XMPP" ); }
 
-require "t/mytestlib.pl";
+require "./t/mytestlib.pl";
 
 my $debug = Net::XMPP::Debug->new(setdefault=>1,
                                  level=>-1,

--- a/t/jid.t
+++ b/t/jid.t
@@ -3,7 +3,7 @@ use Test::More tests=>15;
 
 BEGIN{ use_ok( "Net::XMPP" ); }
 
-require "t/mytestlib.pl";
+require "./t/mytestlib.pl";
 
 my $jid = Net::XMPP::JID->new('host.com/xxx@yyy.com/zzz');
 ok( defined($jid), "new()" );

--- a/t/message.t
+++ b/t/message.t
@@ -3,7 +3,7 @@ use Test::More tests=>136;
 
 BEGIN{ use_ok( "Net::XMPP" ); }
 
-require "t/mytestlib.pl";
+require "./t/mytestlib.pl";
 
 my $debug = Net::XMPP::Debug->new(setdefault=>1,
                                  level=>-1,

--- a/t/packet_iqauth.t
+++ b/t/packet_iqauth.t
@@ -3,7 +3,7 @@ use Test::More tests=>55;
 
 BEGIN{ use_ok( "Net::XMPP" ); }
 
-require "t/mytestlib.pl";
+require "./t/mytestlib.pl";
 
 my $debug = Net::XMPP::Debug->new(setdefault=>1,
                                  level=>-1,

--- a/t/packet_iqroster.t
+++ b/t/packet_iqroster.t
@@ -3,7 +3,7 @@ use Test::More tests=>57;
 
 BEGIN{ use_ok( "Net::XMPP" ); }
 
-require "t/mytestlib.pl";
+require "./t/mytestlib.pl";
 
 my $debug = Net::XMPP::Debug->new(setdefault=>1,
                                  level=>-1,

--- a/t/presence.t
+++ b/t/presence.t
@@ -3,7 +3,7 @@ use Test::More tests=>132;
 
 BEGIN{ use_ok( "Net::XMPP" ); }
 
-require "t/mytestlib.pl";
+require "./t/mytestlib.pl";
 
 my $debug = Net::XMPP::Debug->new(setdefault=>1,
                                  level=>-1,

--- a/t/rawxml.t
+++ b/t/rawxml.t
@@ -3,7 +3,7 @@ use Test::More tests=>54;
 
 BEGIN{ use_ok( "Net::XMPP" ); }
 
-require "t/mytestlib.pl";
+require "./t/mytestlib.pl";
 
 my $message = Net::XMPP::Message->new();
 ok( defined($message), "new()");

--- a/t/roster.t
+++ b/t/roster.t
@@ -3,7 +3,7 @@ use Test::More tests=>75;
 
 BEGIN{ use_ok( "Net::XMPP" ); }
 
-require "t/mytestlib.pl";
+require "./t/mytestlib.pl";
 
 my $debug = Net::XMPP::Debug->new(setdefault=>1,
                                  level=>-1,


### PR DESCRIPTION
    require t/foo.pl

Used to work as a result of the assumed '.' at the end of `@INC`.
This is no longer true under Perl 5.26 without PERL_USE_UNSAFE_INC=1
in your environment (which gets defaulted on under CPAN installers and
under Test::Harness if not explicitly disabled, and will be hard-off
in Perl 5.30)

Bug: https://bugs.gentoo.org/623002